### PR TITLE
Feat/workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/gitlab-ci/job.yml
+++ b/gitlab-ci/job.yml
@@ -1,0 +1,27 @@
+web-build:
+  extends: .build
+  rules:
+    - if: '$BUILD'
+
+web-deploy:
+  extends: .deploy
+  needs:
+    - web-build
+  rules:
+    - if: '$BUILD'
+    - if: '$BUILD == "prod"'
+      when: never
+    - if: '$BUILD == "prod-2"'
+      when: never
+
+prod-web-deploy:
+  extends: .deploy
+  needs:
+    - web-build
+  rules:
+    - if: '$BUILD == "prod"'
+    - if: '$BUILD == "prod-2"'
+  after_script:
+    - docker push $DOCKER_IMAGE_REPO:$TAG
+    - docker tag $DOCKER_IMAGE_REPO:$TAG $DOCKER_IMAGE_REPO:$CI_COMMIT_TAG
+    - docker push $DOCKER_IMAGE_REPO:$CI_COMMIT_TAG

--- a/gitlab-ci/pipeline.yml
+++ b/gitlab-ci/pipeline.yml
@@ -1,16 +1,46 @@
 include:
-  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/gcr.yml
-  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/template.yml
-  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/test.yml
-  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/beta.yml
-  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/prod.yml
-  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/test2.yml
-  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/beta2.yml
-  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/prod2.yml
-  #- https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/release.yml
+  - https://raw.githubusercontent.com/CacaoRick/shared-configuration/master/gitlab-ci/gcr.yml
+  - https://raw.githubusercontent.com/CacaoRick/shared-configuration/master/gitlab-ci/template.yml
+  - https://raw.githubusercontent.com/CacaoRick/shared-configuration/master/gitlab-ci/job.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/gcr.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/template.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/test.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/beta.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/prod.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/test2.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/beta2.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/prod2.yml
+  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/release.yml
 
 stages:
   - build
   - test
   - deploy
   - release
+
+workflow:
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "dev"'
+      variables:
+        BUILD: 'test'
+        TAG: 'latest'
+    - if: '$CI_COMMIT_BRANCH == "dev2"'
+      variables:
+        BUILD: 'test-2'
+        TAG: 'latest-2'
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      variables:
+        BUILD: 'beta'
+        TAG: 'beta'
+    - if: '$CI_COMMIT_BRANCH == "master2"'
+      variables:
+        BUILD: 'beta-2'
+        TAG: 'beta-2'
+    - if: '$CI_COMMIT_TAG =~ /^v\d\.\d\.\d.*/'
+      variables:
+        BUILD: 'prod'
+        TAG: 'stable'
+    - if: '$CI_COMMIT_BRANCH == "stable-2"'
+      variables:
+        BUILD: prod-2
+        TAG: stable-2

--- a/gitlab-ci/pipeline.yml
+++ b/gitlab-ci/pipeline.yml
@@ -1,9 +1,7 @@
 include:
-  - https://raw.githubusercontent.com/CacaoRick/shared-configuration/master/gitlab-ci/gcr.yml
-  - https://raw.githubusercontent.com/CacaoRick/shared-configuration/master/gitlab-ci/template.yml
-  - https://raw.githubusercontent.com/CacaoRick/shared-configuration/master/gitlab-ci/job.yml
-  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/gcr.yml
-  # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/template.yml
+  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/gcr.yml
+  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/template.yml
+  - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/job.yml
   # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/test.yml
   # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/beta.yml
   # - https://raw.githubusercontent.com/tickone/shared-configuration/master/gitlab-ci/env/prod.yml

--- a/gitlab-ci/template.yml
+++ b/gitlab-ci/template.yml
@@ -7,6 +7,7 @@
     paths:
       - image.tar
     expire_in: 1 day
+  interruptible: true
 
 .deploy:
   stage: deploy


### PR DESCRIPTION
- use workflow
- set job-dependencies
- use interruptible in build job

現在變這樣
![image](https://user-images.githubusercontent.com/20147386/128056475-15a35807-508f-4b1a-99a5-66a37a3778ed.png)

不會因為其他 build job 沒完成而跳過 web-deploy
![image](https://user-images.githubusercontent.com/20147386/128059754-2a758cfa-2078-40c6-b937-20394d19d9e1.png)

用 workflow 設定 BUILD 環境，這樣 build 和 deploy job 就通用了，env 資料夾就不用寫每種環境的 yml

然後用了 `interruptible: true`，有新的 build job 跑起來會停掉舊的

再幫我看看有什麼問題